### PR TITLE
Handle object attachments in dashboard

### DIFF
--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -151,11 +151,18 @@ async function loadMsg(id){
 
 function prettyName(path){ try{ return path.split(/[\\/]/).pop(); }catch(e){ return path; } }
 function renderAttachments(list){
-  const el = document.getElementById('atts'); el.innerHTML = '';
-  (list||[]).forEach(p=>{
-     let href = p; if(!href.startsWith('/')){ href = '/out/'+prettyName(href); }
-     const a = document.createElement('a'); a.href = href; a.textContent = prettyName(p); a.target = '_blank'; a.style.marginRight='10px';
-     el.appendChild(a);
+  const el = document.getElementById('atts');
+  el.innerHTML = '';
+  (list || []).forEach(item => {
+    const p = typeof item === 'string' ? item : (item.uri || item.filename);
+    if (!p) return;
+    let href = p.startsWith('/') ? p : '/out/' + prettyName(p);
+    const a = document.createElement('a');
+    a.href = href;
+    a.textContent = prettyName(p);
+    a.target = '_blank';
+    a.style.marginRight = '10px';
+    el.appendChild(a);
   });
 }
 


### PR DESCRIPTION
## Summary
- Allow `renderAttachments` to handle attachment objects and strings when building download links

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5d334909c8324a2b55b56a9e9ba07